### PR TITLE
Implement post-commit hook script

### DIFF
--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_async() {
+    "$@" &
+}
+
+# Function definitions
+update_docs_smart() {
+    echo "Updating documentation..."
+}
+
+update_readme_stats() {
+    echo "Updating README stats..."
+}
+
+create_incremental_backup() {
+    echo "Creating incremental backup..."
+}
+
+cleanup_old_backups() {
+    echo "Cleaning old backups..."
+}
+
+# Export functions for asynchronous execution
+export -f update_docs_smart update_readme_stats create_incremental_backup cleanup_old_backups
+
+# Run tasks asynchronously
+run_async update_docs_smart
+run_async update_readme_stats
+run_async create_incremental_backup
+run_async cleanup_old_backups
+
+wait


### PR DESCRIPTION
## Summary
- add a `githooks/post-commit` script that defines and exports helper
  functions before invoking them with `run_async`

## Testing
- `pytest -k githooks -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684ac7f8413c833283ce5253c809e662