### PR TITLE
Add critical tool tests

### DIFF
--- a/tests/critical/test_jest_tool.py
+++ b/tests/critical/test_jest_tool.py
@@ -1,0 +1,59 @@
+import json
+import os
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("langchain_core.tools", MagicMock(BaseTool=object))
+sys.modules.setdefault("langsmith", MagicMock())
+sys.modules.setdefault("langsmith.client", MagicMock())
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("requests", MagicMock())
+sys.modules.setdefault("httpx", MagicMock())
+
+from tools.jest_tool import JestTool
+
+
+def create_tool():
+    project_root = Path(__file__).resolve().parents[2]
+    return JestTool(str(project_root))
+
+
+def test_extract_param():
+    tool = create_tool()
+    query = "generate test path: src/Button.tsx, code: export const Button = () => {}, type: component"
+    assert tool._extract_param(query, "path") == "src/Button.tsx"
+    assert tool._extract_param(query, "type") == "component"
+    assert tool._extract_param(query, "code").startswith("export")
+
+
+def test_generate_component_test():
+    tool = create_tool()
+    code = "import React from 'react'; export default function Button(){ return <button>Ok</button>; }"
+    result = json.loads(tool._generate_test("src/Button.tsx", code, "component"))
+    data = result["data"]
+    assert data["test_type"] == "component"
+    assert "Button" in data["test_code"]
+    assert data["suggested_test_path"].endswith(".test.tsx")
+
+
+def test_list_tests():
+    tool = create_tool()
+    result = json.loads(tool._list_tests("src/Button.tsx"))
+    data = result["data"]
+    assert data["component"] == "Button"
+    assert isinstance(data["test_files"], list)
+
+
+def test_run_test_missing_file(tmp_path):
+    tool = create_tool()
+    result = json.loads(tool._run_test("nonexistent.test.ts"))
+    data = result["data"]
+    assert not data["success"]
+
+
+def test_get_coverage_filter():
+    tool = create_tool()
+    result = json.loads(tool._get_coverage("src/components/Button.tsx"))
+    data = result["data"]
+    assert data["coverage"]["files"][0]["path"] == "src/components/Button.tsx"

--- a/tests/critical/test_supabase_tool.py
+++ b/tests/critical/test_supabase_tool.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+import pytest
+
+sys.modules.setdefault("supabase", MagicMock())
+sys.modules.setdefault("langchain_core.tools", MagicMock(BaseTool=object))
+sys.modules.setdefault("langsmith", MagicMock())
+sys.modules.setdefault("langsmith.client", MagicMock())
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("requests", MagicMock())
+sys.modules.setdefault("httpx", MagicMock())
+
+from tools.supabase_tool import SupabaseTool
+
+
+def create_tool(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
+    project_root = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(project_root)
+    return SupabaseTool()
+
+
+def test_plan_recognizes_actions(monkeypatch):
+    tool = create_tool(monkeypatch)
+    assert tool.plan("show schema")["action"] == "get_schema"
+    assert tool.plan("service pattern example")["action"] == "get_service_pattern"
+    assert tool.plan("SELECT * FROM products")["action"] == "execute_query"
+    assert tool.plan("hello")["action"] == "generic_response"
+
+
+def test_get_mock_schema(monkeypatch):
+    tool = create_tool(monkeypatch)
+    schema = tool._get_mock_schema()
+    assert "Database" in schema
+
+
+def test_run_returns_mock_data(monkeypatch):
+    tool = create_tool(monkeypatch)
+    result = tool._run("SELECT * FROM products")
+    assert "Handmade Ceramic Mug" in result
+
+
+def test_get_service_pattern(monkeypatch):
+    tool = create_tool(monkeypatch)
+    pattern = tool._get_service_pattern()
+    assert "Service" in pattern

--- a/tools/jest_tool.py
+++ b/tools/jest_tool.py
@@ -207,6 +207,14 @@ class JestTool(ArtesanatoBaseTool):
         # Check if component takes props by looking for a Props type/interface
         has_props = "Props" in component_code or "props" in component_code
 
+        additional_test = (
+            "test('renders with different props', () => {\n"
+            "    // Test component with various prop combinations\n"
+            f"    render(<{component_name} {{ /* different props */ }} />);\n"
+            "    // Add assertions for prop-specific behavior\n"
+            "  });" if has_props else ""
+        )
+
         test_code = f"""import React from 'react';
 import {{ render, screen }} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -230,7 +238,7 @@ describe('{component_name}', () => {{
     // expect(screen.getByText(/new content/i)).toBeInTheDocument();
   }});
 
-  {"test('renders with different props', () => {\n    // Test component with various prop combinations\n    render(<" + component_name + " { /* different props */ } />);\n    // Add assertions for prop-specific behavior\n  });" if has_props else ""}
+  {additional_test}
 }});
 """
         return test_code
@@ -392,9 +400,11 @@ describe('{util_name}', () => {{
                     data={
                         "component": component_name,
                         "test_files": test_files,
-                        "message": f"Found {
-                            len(test_files)} potential test locations for {
-                            component_name or 'the project'}."}))
+                        "message": (
+                            f"Found {len(test_files)} potential test locations for "
+                            f"{component_name or 'the project'}."
+                        )
+                    }))
         except Exception as e:
             return json.dumps(self.handle_error(e, "JestTool._list_tests"))
 
@@ -459,8 +469,10 @@ describe('{util_name}', () => {{
             return json.dumps(
                 self.format_response(
                     data={
-                        "message": f"Coverage data retrieved for {
-                            path or 'the entire project'}",
-                        "coverage": coverage_data}))
+                        "message": (
+                            f"Coverage data retrieved for {path or 'the entire project'}"
+                        ),
+                        "coverage": coverage_data,
+                    }))
         except Exception as e:
             return json.dumps(self.handle_error(e, "JestTool._get_coverage"))

--- a/tools/supabase_tool.py
+++ b/tools/supabase_tool.py
@@ -196,16 +196,16 @@ class SupabaseTool(ArtesanatoBaseTool):
                         'is_nullable') == "YES" else "NOT NULL"
 
                     # Add default value if present
-                    default = f" DEFAULT {
-                        column.get('column_default')}" if column.get('column_default') else ""
+                    default_val = column.get('column_default')
+                    default = f" DEFAULT {default_val}" if default_val else ""
 
                     # Add identity/serial info
                     identity = f" {column.get('identity_generation')}" if column.get(
                         'identity_generation') else ""
 
                     # Format the complete column definition
-                    column_def = f"{
-                        column.get('column_name')}: {data_type} {nullable}{default}{identity}"
+                    column_name = column.get('column_name')
+                    column_def = f"{column_name}: {data_type} {nullable}{default}{identity}"
                     tables[table_name].append(column_def)
 
                 # Extract foreign key constraints
@@ -279,9 +279,9 @@ class SupabaseTool(ArtesanatoBaseTool):
                 if hasattr(pk_response, 'data') and pk_response.data:
                     schema_text += "## Primary Keys\n\n"
                     for pk in pk_response.data:
-                        schema_text += f"- {
-                            pk.get('table_name')}: {
-                            pk.get('column_name')}\n"
+                        table = pk.get('table_name')
+                        column = pk.get('column_name')
+                        schema_text += f"- {table}: {column}\n"
 
                 return schema_text
             else:


### PR DESCRIPTION
## Summary
- add fast validation tests for JestTool and SupabaseTool
- fix small syntax issues in JestTool and SupabaseTool to run tests reliably

## Testing
- `pytest -o addopts='' tests/critical/test_supabase_tool.py tests/critical/test_jest_tool.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac7b50cac83328a4a533b11a1e4d7